### PR TITLE
think these were meant to be relabeled for the 1.2.0k release

### DIFF
--- a/extras/coffee-script-iced-large.js
+++ b/extras/coffee-script-iced-large.js
@@ -1,5 +1,5 @@
 /**
- * CoffeeScript Compiler v1.2.0j
+ * CoffeeScript Compiler v1.2.0k
  * http://coffeescript.org
  *
  * Copyright 2011, Jeremy Ashkenas

--- a/extras/coffee-script-iced.js
+++ b/extras/coffee-script-iced.js
@@ -1,5 +1,5 @@
 /**
- * CoffeeScript Compiler v1.2.0j
+ * CoffeeScript Compiler v1.2.0k
  * http://coffeescript.org
  *
  * Copyright 2011, Jeremy Ashkenas

--- a/extras/coffee-script.js
+++ b/extras/coffee-script.js
@@ -1,5 +1,5 @@
 /**
- * CoffeeScript Compiler v1.2.0j
+ * CoffeeScript Compiler v1.2.0k
  * http://coffeescript.org
  *
  * Copyright 2011, Jeremy Ashkenas


### PR DESCRIPTION
I think you have a `k` release with these `extras` labeled as `j`.
