### PR TITLE
Fix file path including '\' (mostly Windows path)

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -32,7 +32,7 @@
       require.extensions[e] = function(module, filename) {
         var content;
         content = compile(fs.readFileSync(filename, 'utf8'), {
-          filename: filename
+          filename: filename.replace(/\\/g, "\\\\")
         });
         return module._compile(content, filename);
       };


### PR DESCRIPTION
In Windows platform, unescaped \ makes some problem.

compiled string:
  (function(__iced_k) {
    __iced_deferrals = new iced.Deferrals(__iced_k, {
      filename: "E:\Work\123456\trunk\controllers\user\a.iced" // unescaped!!!
    });

and error message:
E:\Work\123456\trunk\controllers\user\a.iced:14
      filename: "E:\Work\123456\trunk\controllers\user\a.iced"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: Unexpected token ILLEGAL
    at Module._compile (module.js:437:25)
    at Object.require.extensions.(anonymous function) [as .iced](E:Workpub272
trunknode_modulesiced-coffee-scriptlibcoffee-scriptcoffee-script.js:39:23)

    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at E:\Work\pub272\trunk\app.iced:106:9
    at Deferrals.exports.generator.runtime.Deferrals.Deferrals._call (E:\Work\pu
b272\trunk\node_modules\iced-coffee-script\lib\coffee-script\iced.js:98:18)
    at Deferrals.exports.generator.runtime.Deferrals.Deferrals._fulfill (E:\Work
\pub272\trunk\node_modules\iced-coffee-script\lib\coffee-script\iced.js:107:23)
    at RedisClient.exports.generator.intern.makeDeferReturn.ret (E:\Work\pub272\
trunk\node_modules\iced-coffee-script\lib\coffee-script\iced.js:56:20)
    at RedisClient.EventEmitter.emit (events.js:85:17)
