### PR TITLE
Fixed await filename escape issue.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3225,7 +3225,7 @@
       }
       if (o.filename != null) {
         fn_lhs = new Value(new Literal(iced["const"].filename));
-        fn_rhs = new Value(new Literal('"' + o.filename + '"'));
+        fn_rhs = new Value(new Literal('"' + o.filename.replace('\\', '\\\\') + '"'));
         fn_assignment = new Assign(fn_lhs, fn_rhs, "object");
         assignments.push(fn_assignment);
       }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2487,7 +2487,7 @@ exports.Await = class Await extends Base
 
     if o.filename?
       fn_lhs = new Value new Literal iced.const.filename
-      fn_rhs = new Value new Literal '"' + o.filename + '"'
+      fn_rhs = new Value new Literal '"' + o.filename.replace('\\', '\\\\') + '"'
       fn_assignment = new Assign fn_lhs, fn_rhs, "object"
       assignments.push fn_assignment
 


### PR DESCRIPTION
Because the filename on Windows would have directory separators as a single backslash.

Of course, in code this is an escape, so certain names would break ICS (e.g." ..\nodes.iced").
