### PR TITLE
Fixed await filename escape on long paths on Win, really

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3225,7 +3225,7 @@
       }
       if (o.filename != null) {
         fn_lhs = new Value(new Literal(iced["const"].filename));
-        fn_rhs = new Value(new Literal('"' + o.filename.replace('\\', '\\\\') + '"'));
+        fn_rhs = new Value(new Literal('"' + o.filename.replace(/\\/g, '\\\\') + '"'));
         fn_assignment = new Assign(fn_lhs, fn_rhs, "object");
         assignments.push(fn_assignment);
       }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2490,7 +2490,7 @@ exports.Await = class Await extends Base
 
       # Replace '\' with '\\' to make the emitted code safe for Windows
       # paths.  See Issue #84. Thanks to @Deathspike for this patch
-      fn_rhs = new Value new Literal '"' + o.filename.replace('\\', '\\\\') + '"'
+      fn_rhs = new Value new Literal '"' + o.filename.replace(/\\/g, '\\\\') + '"'
       fn_assignment = new Assign fn_lhs, fn_rhs, "object"
       assignments.push fn_assignment
 


### PR DESCRIPTION
Now it replaces only with first backslash, so on more complex paths it's broken.
