### PR TITLE
Fix for #98: deal with variable-free for [...] loops.

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3000,7 +3000,13 @@ exports.For = class For extends While
       a4 = new Assign @index, keys_access
       pre_body.unshift a4
 
-    else if @range and @name
+    else if @range
+      if not @name
+        # Handle the case of 'for [1..5]' (without a looping variable).
+        # - Issue #98 as reported by @davidbau
+        # If the user didn't give a looping variable, use the made-up one.
+        @name = new Literal d.kvar
+
       # Handle the case of 'for i in [0..10]'
       # Be careful to handle *negative* stride, see
       # - Issue #86 as reported by @davidbau

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -562,6 +562,17 @@ atest "negative strides with expression", (cb) ->
     last2 = i
   cb ((total1 is 15) and (last1 is 1) and (total2 is 20) and (last2 is 2)), {}
 
+atest "loop without looping variable", (cb) ->
+  count = 6
+  total1 = 0
+  for [1..count]
+    await delay defer(), 0
+    total1 += 1
+  total2 = 0
+  for i in [count..1]
+    await delay defer(), 0
+    total2 += 1
+  cb ((total1 is 6) and (total2 is 6)), {}
 
 atest "destructuring assignment in defer", (cb) ->
   j = (cb) ->


### PR DESCRIPTION
This small fix (thanks to Kevin Zatloukal) uses a generated variable
for a variable-free for loop; and it adds a small test for that case.
