### PR TITLE
Fix autocb for fat arrow functions.

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -177,6 +177,7 @@ exports.Base = class Base
     extras.push "A" if @icedNodeFlag
     extras.push "L" if @icedLoopFlag
     extras.push "P" if @icedCpsPivotFlag
+    extras.push "B" if @icedIsAutocbCode
     extras.push "C" if @icedHasAutocbFlag
     extras.push "D" if @icedParentAwait
     extras.push "G" if @icedFoundArguments
@@ -1783,7 +1784,7 @@ exports.Code = class Code extends Base
       node.error "multiple parameters named '#{name}'" if name in uniqs
       uniqs.push name
 
-    wasEmpty = false if @icedHasAutocbFlag
+    wasEmpty = false if @icedIsAutocbCode
 
     @body.makeReturn() unless wasEmpty or @noReturn
     code = 'function'
@@ -1845,7 +1846,7 @@ exports.Code = class Code extends Base
     # case.
     #
     if @icedNodeFlag and not @icedgen
-      r = if @icedHasAutocbFlag then iced.const.autocb else iced.const.k_noop
+      r = if @icedIsAutocbCode then iced.const.autocb else iced.const.k_noop
       rhs = new Value new Literal r
       lhs = new Value new Literal iced.const.k
       @body.unshift(new Assign lhs, rhs, null, { icedlocal : yes } )
@@ -1866,8 +1867,9 @@ exports.Code = class Code extends Base
       if param.name instanceof Literal and param.name.value is iced.const.autocb
         o.foundAutocb = true
         break
-    @icedHasAutocbFlag = o.foundAutocb
     super parent, o
+    @icedHasAutocbFlag = fa_prev
+    @icedIsAutocbCode = o.foundAutocb
     @icedFoundArguments = o.foundArguments
     o.foundAwaitFunc = faf_prev
     o.foundArguments = fg_prev

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -141,6 +141,21 @@ atest "simple autocb operations", (cb) ->
   await foo defer b
   cb(b, {})
 
+atest "fat arrow autocb operations", (cb) ->
+  b = false
+  foo = (autocb) =>
+    await delay defer()
+    true
+  await foo defer b
+  cb(b, {})
+
+atest "returning autocb as last value of a block", (cb) ->
+  b = false
+  maker = (val) -> (autocb) -> val
+  foo = maker true
+  await foo defer b
+  cb(b, {})
+
 atest "AT variable works in an await (1)", (cb) ->
   class MyClass
     constructor : ->


### PR DESCRIPTION
This fixes #148.

Previously, when generating fat arrow functions with ```(autocb) =>```

The ```(function(_this) { return function(autocb) {..} })(this)``` would get transformed into the incorrect form: ```(function(_this) { autocb(function(autocb) {..}}))(this)```

Now we put an explicit non-autocb-return into the fat arrow binding to avoid this problem.  This change also adds a test for this case.