### PR TITLE
Fix #146

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3339,7 +3339,7 @@
         v = _ref2[_i];
         name = v.compile(o, LEVEL_LIST);
         scope = o.scope;
-        scope.add(name, 'var');
+        scope.find(name, 'var');
       }
       return call.compileNode(o);
     };

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2570,7 +2570,7 @@ exports.Defer = class Defer extends Base
     for v in @vars
       name = v.compile o, LEVEL_LIST
       scope = o.scope
-      scope.add name, 'var'
+      scope.find name, 'var'
     call.compileNode o
 
   icedWalkAst : (p, o) ->

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -615,6 +615,19 @@ atest 'defer + class member assignments', (cb) ->
   await c.f defer z
   cb(c.x is 3 and c.y is 4 and z is 5,  {})
 
+# tests bug #146 (github.com/maxtaco/coffee-script/issues/146)
+atest 'deferral variable with same name as a parameter in outer scope', (cb) ->
+  val = 0
+  g = (autocb) ->
+    return 2
+  f = (x) ->
+    (->
+      val = x
+      await g defer(x)
+    )()
+  f 1
+  cb(val is 1, {})
+
 # helper to assert that a string should fail compilation
 cantCompile = (code) ->
   throws -> CoffeeScript.compile code


### PR DESCRIPTION
Fixes: #146

Deferral variables were being given `var` declarations even when the variable would have the same name as a parameter in an outer scope, causing the parameter variable to be overridden.

I fixed this by checking whether the deferral variable already exists in the current scope before adding it to the scope.