### PR TITLE
Fix #144

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2584,6 +2584,10 @@ quote_path_for_emission = (n) ->
   # paths.  See Issue #84. Thanks to @Deathspike for this patch
   '"' + n.replace(/\\/g, '\\\\') + '"'
 
+remove_quotes = (n) ->
+  # Remove all single and double quotes to make the emitted funcname safe
+  '"' + n.replace(/["']/g, '') + '"'
+
 require_top_dir = () ->
   # See #139, need to use window-safe pathname quoting for requring
   # the top current directory. Windows!
@@ -2619,7 +2623,7 @@ exports.Await = class Await extends Base
 
     if n = @parentFunc?.icedTraceName()
       func_lhs = new Value new Literal iced.const.funcname
-      func_rhs = new Value new Literal '"' + n + '"'
+      func_rhs = new Value new Literal remove_quotes n
       func_assignment = new Assign func_lhs, func_rhs, "object"
       assignments.push func_assignment
 

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -628,6 +628,18 @@ atest 'deferral variable with same name as a parameter in outer scope', (cb) ->
   f 1
   cb(val is 1, {})
 
+atest 'funcname with double quotes is safely emitted', (cb) ->
+  v = 0
+  b = {}
+  
+  f = -> v++
+  b["xyz"] = ->
+    await f defer()
+
+  do b["xyz"]
+
+  cb(v is 1, {})  
+
 # helper to assert that a string should fail compilation
 cantCompile = (code) ->
   throws -> CoffeeScript.compile code


### PR DESCRIPTION
Fix for https://github.com/maxtaco/coffee-script/issues/144 - extra double quotes surrounding `funcname` property when compiled. 
Added a simple function (in the style of `quote_path_for_emission`) to remove all single and double quotes in the name, and then surround by double quotes. Also added a test, with the example from the issue.