### PR TITLE
Fix #155 (RequireJS bug)

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -146,7 +146,7 @@ task 'build:browser', 'rebuild the merged script for inclusion in the browser', 
   b.add "./lib/coffee-script/browser.js"
   await b.bundle { standalone : 'CoffeeScript' }, defer err, code
   console.error err if err?
-  code = "(function(root){\n" + code + "\nroot.CoffeeScript = CoffeeScript;\n})(this);"
+  code = "(function(root){\n" + code + "\nif (typeof CoffeeScript !== 'undefined') { root.CoffeeScript = CoffeeScript; }\n})(this);"
 
   fs.writeFileSync outFileName(false), header + '\n' + code
   unless process.env.MINIFY is 'false'


### PR DESCRIPTION
I figured out what the `root.CoffeeScript = CoffeeScript` line of code that I was talking about in #155 does. It's used to make the 'test:browser' task (at the very bottom of Cakefile) work, right? So I guess the solution is to test whether `CoffeeScript` is defined before running that line of code, since with AMD systems like RequireJS the browserify code will never set the `CoffeeScript` global, causing the ReferenceError to occur on that line.