### PR TITLE
Add noIcedTransform option to CoffeeScript.nodes()

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -99,11 +99,16 @@
   });
 
   exports.nodes = withPrettyErrors(function(source, options) {
+    var ast;
     if (typeof source === 'string') {
-      return iced_transform(parser.parse(lexer.tokenize(source, options)), options);
+      ast = parser.parse(lexer.tokenize(source, options));
     } else {
-      return iced_transform(parser.parse(source), options);
+      ast = parser.parse(source);
     }
+    if (!options.noIcedTransform) {
+      ast = iced_transform(ast, options);
+    }
+    return ast;
   });
 
   exports.run = function(code, options) {

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -92,9 +92,12 @@ exports.tokens = withPrettyErrors (code, options) ->
 # or traverse it by using `.traverseChildren()` with a callback.
 exports.nodes = withPrettyErrors (source, options) ->
   if typeof source is 'string'
-    iced_transform(parser.parse(lexer.tokenize(source, options)), options)
+    ast = parser.parse(lexer.tokenize(source, options))
   else
-    iced_transform(parser.parse(source),options)
+    ast = parser.parse(source)
+
+  ast = iced_transform(ast, options) unless options.noIcedTransform
+  ast
 
 # Compile and execute a string of CoffeeScript (on the server), correctly
 # setting `__filename`, `__dirname`, and relative `require()`.


### PR DESCRIPTION
Hi, I have been trying to do some Iced CoffeeScript code instrumentation by manipulating the transformed AST returned by `CoffeeScript.nodes()`, and have realized it would be much better to instrument the AST *before* the iced transformation. There's currently no way to do this, so this change adds a `noIcedTransform` option to `CoffeeScript.nodes()`, which lets you write code like this:

```coffeescript
ast = iced.nodes(code, noIcedTransform: true)
# ...manipulate ast...
ast = ast.icedTransform()
js = ast.compile()
```