### PR TITLE
Inline runtime generation, fix test:browser

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -138,15 +138,12 @@ task 'build:parser', 'rebuild the Jison parser (run build first)', ->
 task 'build:browser', 'rebuild the merged script for inclusion in the browser', ->
   code = ''
 
-  runtime_str = fs.readFileSync "extras/inline-runtime.js", 'utf-8'
-  runtime_str_str = helpers.strToJavascript runtime_str
-
-  code = """
-    require['iced-runtime-3'] = #{runtime_str};
-    require['iced-runtime-3'].text = #{runtime_str_str};
+  code += """
+    require['iced-runtime-3'] = #{fs.readFileSync "lib/coffee-script/inline-runtime.js"};
 
   """
-  for name in ['helpers', 'rewriter', 'lexer', 'parser', 'scope', 'nodes', 'sourcemap', 'coffee-script', 'browser']
+
+  for name in ['helpers', 'rewriter', 'lexer', 'parser', 'scope', 'nodes', 'sourcemap', 'coffee-script', 'browser', 'inline-runtime-str']
     code += """
       require['./#{name}'] = (function() {
         var exports = {}, module = {exports: exports};
@@ -154,6 +151,7 @@ task 'build:browser', 'rebuild the merged script for inclusion in the browser', 
         return module.exports;
       })();
     """
+
   code = """
     (function(root) {
       var CoffeeScript = function() {
@@ -193,7 +191,8 @@ task 'build:inline-runtime', 'build the inline iced3 runtime', ->
     }());
   """
 
-  fs.writeFileSync 'extras/inline-runtime.js', header + '\n' + code
+  fs.writeFileSync 'lib/coffee-script/inline-runtime.js', header + '\n' + code
+  fs.writeFileSync 'lib/coffee-script/inline-runtime-str.js', "module.exports = #{helpers.strToJavascript(code)}"
   console.log 'built inline iced3 runtime'
 
 task 'doc:site', 'watch and continually rebuild the documentation for the website', ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -430,6 +430,9 @@ compileOptions = (filename, base) ->
     runtime: opts.runtime
     runforce: opts.runforce
   }
+
+  handleIcedOptions answer
+
   if filename
     if base
       cwd = process.cwd()

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -193,3 +193,13 @@ exports.nameWhitespaceCharacter = (string) ->
     when '\r' then 'carriage return'
     when '\t' then 'tab'
     else string
+
+# Transforms multiline string to JavaScript string literal, ready to
+# emit by the compiler.
+exports.strToJavascript = (source) ->
+  lines = source.split '\n'
+
+  lines = lines.map (line) ->
+    line.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+
+  "'#{lines.join('\\n')}'"

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2406,20 +2406,18 @@ class IcedRuntime extends Block
     if o.runtime and not @foundDefer and not o.runforce
       v = "none"
 
-    window_mode = false
-    window_val = null
-
-    if v in ['inline']
-      return @makeCode @inlineRuntime()
+    # 'inline' and 'window' runtimes are emitted with makeCode and
+    # include extras/inline-runtime.js file.
+    switch (v)
+      when "inline"
+        return @makeCode @inlineRuntime('var iced')
+      when "window"
+        return @makeCode @inlineRuntime('window.iced')
 
     inc = null
-    inc = switch (v)
-      when "inline", "window"
-        window_mode = true if v is "window"
-        if window_mode
-          window_val = new Value new Literal v
-        InlineRuntime.generate(if window_val then window_val.copy() else null)
+    inc = switch(v)
       when "node", "browserify", "interp"
+        # Emit a `require` call.
         interp = (v is "interp")
         qmodname = if interp then require_top_dir() else "'iced-runtime-3'"
         accessname = iced.const.ns
@@ -2440,9 +2438,9 @@ class IcedRuntime extends Block
     if @isEmpty() then []
     else               super o
 
-  inlineRuntime: () ->
+  inlineRuntime: (lefthand) ->
     fs = require('fs')
-    "var iced = #{fs.readFileSync "extras/inline-runtime.js"};"
+    "#{lefthand} = #{fs.readFileSync "extras/inline-runtime.js"};"
 
 #### Try
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2409,6 +2409,9 @@ class IcedRuntime extends Block
     window_mode = false
     window_val = null
 
+    if v in ['inline']
+      return @makeCode @inlineRuntime()
+
     inc = null
     inc = switch (v)
       when "inline", "window"
@@ -2436,6 +2439,10 @@ class IcedRuntime extends Block
 
     if @isEmpty() then []
     else               super o
+
+  inlineRuntime: () ->
+    fs = require('fs')
+    "var iced = #{fs.readFileSync "extras/inline-runtime.js"};"
 
 #### Try
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2411,7 +2411,7 @@ class IcedRuntime extends Block
     # include extras/inline-runtime.js file.
     switch (v)
       when "inline"
-        return @makeCode 'var iced;\n' + @inlineRuntime('iced')
+        return @makeCode @inlineRuntime('var iced')
       when "window"
         return @makeCode @inlineRuntime('window.iced')
 
@@ -2440,22 +2440,8 @@ class IcedRuntime extends Block
     else               super o
 
   inlineRuntime: (lefthand) ->
-    if iced.text
-      # If the compiler is ran from the browser and it uses the inline
-      # runtime, the runtime will already have the 'text' property we
-      # can just "pass along".
-      runtime_str = iced.text
-    else
-      # If not (compiler is stand alone), use readFileSync to get the
-      # runtime.
-      fs = require('fs')
-      runtime_str = fs.readFileSync "extras/inline-runtime.js", 'utf-8'
-
-    runtime_str_str = strToJavascript runtime_str
-
     """
-    #{lefthand} = #{runtime_str};
-    #{lefthand}.text = #{runtime_str_str};
+    #{lefthand} = #{require('./inline-runtime-str')};
 
     """
 

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -835,9 +835,7 @@ test "helpers.strToJavascript and back", ->
   # We use this to "encode" JavaScript files so naturally this test
   # should try to encode some JavaScript code snippet.
   test_string = str_to_js.toString()
-
   javascript_literal = str_to_js test_string
-
   eval "var back_to_string = #{javascript_literal};"
 
   eq back_to_string, test_string

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -796,4 +796,3 @@ cb true, {}
 ''', { bare: true }
 
   eq js.trim().indexOf("(function() {"), 0
-

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -796,3 +796,48 @@ cb true, {}
 ''', { bare: true }
 
   eq js.trim().indexOf("(function() {"), 0
+
+atest "eval iced", (test_cb) ->
+  global.cb = ->
+    delete global.cb
+    test_cb true, {}
+
+  result = CoffeeScript.eval """
+await setTimeout defer(), 1
+cb()
+""", { runtime: 'inline' }
+
+if vm = require? 'vm'
+  atest "eval sandbox iced", (test_cb) ->
+    createContext = vm.Script.createContext ? vm.createContext
+    sandbox = createContext()
+    sandbox.delay = delay
+    sandbox.cb = ->
+      test_cb true, {}
+
+    result = CoffeeScript.eval """
+  await delay defer()
+  cb()
+  """, { runtime: 'inline', sandbox }
+
+atest "iced coffee all the way down", (cb) ->
+  js = CoffeeScript.compile """
+  await delay defer()
+  js_inside = CoffeeScript.compile 'await delay defer()\\ncb true, {}', { runtime: 'inline' }
+  eval js_inside
+  """, { bare: true, runtime: 'inline' }
+
+  eval js
+
+test "helpers.strToJavascript and back", ->
+  str_to_js = CoffeeScript.helpers.strToJavascript
+
+  # We use this to "encode" JavaScript files so naturally this test
+  # should try to encode some JavaScript code snippet.
+  test_string = str_to_js.toString()
+
+  javascript_literal = str_to_js test_string
+
+  eval "var back_to_string = #{javascript_literal};"
+
+  eq back_to_string, test_string


### PR DESCRIPTION
Added inline runtime generation with `build:inline_runtime` task. The runtime is generated to `extras/inline-runtime.js` and is used in `nodes.coffee` to emit IcedRuntime, if the option is set to `inline` or `window`.

This method, however, limits compilation capabilities of iced as browser library. Iced in browser will not be able to emit inline runtime, because there will be no `inline-runtime.js` text file anywhere. Compiling with `runtime: none` and letting it use runtime from `iced` global variable will work - and that's what `test:browser` Cake task does right now.

All tests pass, for both `test` and `test:browser`. Keep in mind that `test:browser` runs less tests, grep `testingBrowser` to see which test files are skipped.
