### PR TITLE
Fixed emitting traces for Deferrals

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2350,6 +2350,12 @@ exports.Await = class Await extends Base
       func_assignment = new Assign func_lhs, func_rhs, "object"
       assignments.push func_assignment
 
+    if o.filename
+      fn_lhs = new Value new Literal iced.const.filename
+      fn_rhs = new Value new Literal quote_path_for_emission o.filename
+      fn_assignment = new Assign fn_lhs, fn_rhs, "object"
+      assignments.push fn_assignment
+
     # { parent : __iced_passed_deferrals, funcname : foo }
     trace = new Obj assignments, true
 

--- a/test/iced.coffee
+++ b/test/iced.coffee
@@ -890,3 +890,37 @@ test "helpers.strToJavascript and back", ->
   eval "var back_to_string = #{javascript_literal};"
 
   eq back_to_string, test_string
+
+# Tests if we are emitting 'traces' correctly and if runtime uses
+# them to generate proper errors.
+atest "overused deferral error message", (test_cb) ->
+  real_warn = console.error
+
+  console.error = (msg) ->
+    console.error = real_warn
+    if msg.indexOf('test/iced.coffee:') != -1 and msg.indexOf('<anonymous>') != -1
+      test_cb true, {}
+    else
+      console.log 'Unexpected overused deferral msg:', msg
+      test_cb false, {}
+
+  foo = (cb) -> cb(); cb()
+  await foo defer()
+
+atest "overused deferral error message 2", (test_cb) ->
+  real_warn = console.error
+
+  console.error = (msg) ->
+    console.error = real_warn
+    if msg.indexOf('test/iced.coffee:') != -1 and msg.indexOf('A.b') != -1
+      test_cb true, {}
+    else
+      console.log 'Unexpected overused deferral msg:', msg
+      test_cb false, {}
+
+  class A
+    b: () ->
+      foo = (cb) -> cb(); cb()
+      await foo defer()
+
+  new A().b()


### PR DESCRIPTION
Traces did not get 'filename' property, which resulted in confusing
runtime warnings, like:

`ICED warning: overused deferral at <anonymous> (undefined:3)`

Fixed this by adding filename in Await.transform.

Added new tests that check for this issue.

Fixes #174
