### PR TITLE
Better traces for iced errors

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1459,6 +1459,16 @@ exports.Assign = class Assign extends Base
           @value.klass = new Value @variable.base, properties
           @value.name  = name
           @value.variable = @variable
+      else if @variable.base instanceof Literal
+        # Try to pass the variable to value if it's a simple function
+        # assignment, like:
+        #
+        # > foo = (param) -> function_body
+        #
+        # so iced can generate better debug traces, instead of saying
+        # that error was in "<anonymous>". Most functions in coffee
+        # anonymous.
+        @value.variable = @variable
     unless @context
       varBase = @variable.unwrapAll()
       unless varBase.isAssignable()
@@ -1814,6 +1824,7 @@ exports.Code = class Code extends Base
     parts = []
     parts.push n if (n = @klass?.base?.value)?
     parts.push n if (n = @name?.name?.value)?
+    parts.push "<anonymous: #{n}>" if (n = @variable?.base?.value)?
     parts.join '.'
 
   # /IcedCoffeeScript Additions


### PR DESCRIPTION
This tries to improve the default `ICED warning: overused deferral at <anonymous>` error messages that are emitted for most of the functions. Most of functions in coffee are anonymous functions assigned to a variable. But we can try to capture name of that variable so it's easier to know what to look for in case of errors.

```
anon_func = ->
    foo = (cb) -> cb(); cb()
    await foo defer()

anon_func()
```

Will produce: `ICED warning: overused deferral at <anonymous: anon_func> (/home/zapu/iced_work_2016/iced-coffee-script/dead_await.iced:3)`

Top-level bug like this:

```
foo = (cb) -> cb(); cb()
await foo defer()
```

Will have the standard behavior of `ICED warning: overused deferral at <anonymous> (/home/zapu/iced_work_2016/iced-coffee-script/dead_await.iced:3)`

This is not perfect, however, so things like this:

```
anon_func = (->
    foo = (cb) -> cb(); cb()
    await foo defer())

anon_func()
```

will still give: `ICED warning: overused deferral at <anonymous> (/home/zapu/iced_work_2016/iced-coffee-script/dead_await.iced:3)`
