### PR TITLE
Fix for source map test from mainline

### DIFF
--- a/test/sourcemap.coffee
+++ b/test/sourcemap.coffee
@@ -16,9 +16,6 @@ test "encodeVlq tests", ->
   for pair in vlqEncodedValues
     eq ((new SourceMap).encodeVlq pair[0]), pair[1]
 
-eqJson = (a, b) ->
-  eq (JSON.stringify JSON.parse a), (JSON.stringify JSON.parse b)
-
 test "SourceMap tests", ->
   map = new SourceMap
   map.add [0, 0], [0, 0]
@@ -28,11 +25,28 @@ test "SourceMap tests", ->
   map.add [3, 0], [3, 4]
 
   testWithFilenames = map.generate {
-        sourceRoot: "",
-        sourceFiles: ["source.coffee"],
-        generatedFile: "source.js"}
-  eqJson testWithFilenames, '{"version":3,"file":"source.js","sourceRoot":"","sources":["source.coffee"],"names":[],"mappings":"AAAA;;IACK,GAAC,CAAG;IAET"}'
-  eqJson map.generate(), '{"version":3,"file":"","sourceRoot":"","sources":[""],"names":[],"mappings":"AAAA;;IACK,GAAC,CAAG;IAET"}'
+    sourceRoot: ""
+    sourceFiles: ["source.coffee"]
+    generatedFile: "source.js"
+  }
+
+  deepEqual testWithFilenames, {
+    version: 3
+    file: "source.js"
+    sourceRoot: ""
+    sources: ["source.coffee"]
+    names: []
+    mappings: "AAAA;;IACK,GAAC,CAAG;IAET"
+  }
+
+  deepEqual map.generate(), {
+    version: 3
+    file: ""
+    sourceRoot: ""
+    sources: [""]
+    names: []
+    mappings: "AAAA;;IACK,GAAC,CAAG;IAET"
+  }
 
   # Look up a generated column - should get back the original source position.
   arrayEq map.sourceLocation([2,8]), [1,9]


### PR DESCRIPTION
I don't know if that's a correct merge strategy and how it will end up looking after merging this pull request - I simply merged coffeescript/master onto a new branch based on iced3.

The source map test now passes. I also checked if it generated the maps by doing `iced3 -c -p -M test_file.iced` and it looked fine.
