### PR TITLE
suppress a missing callback deprecation warning

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1187,11 +1187,11 @@
     };
 
     Value.prototype.icedToSlot = function(i) {
-      var sufffix, suffix;
+      var suffix;
       if (this.base instanceof Obj) {
         return this.base.icedToSlot(i);
       }
-      sufffix = null;
+      suffix = null;
       if (this.properties && this.properties.length) {
         suffix = this.properties.pop();
       }

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -142,7 +142,7 @@
     fd = fs.openSync(filename, 'a');
     repl.rli.addListener('line', function(code) {
       if (code && code.length && code !== '.history' && lastLine !== code) {
-        fs.write(fd, "" + code + "\n");
+        fs.writeSync(fd, "" + code + "\n");
         return lastLine = code;
       }
     });

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -129,7 +129,7 @@ addHistory = (repl, filename, maxSize) ->
   repl.rli.addListener 'line', (code) ->
     if code and code.length and code isnt '.history' and lastLine isnt code
       # Save the latest command in the file
-      fs.write fd, "#{code}\n"
+      fs.writeSync fd, "#{code}\n"
       lastLine = code
 
   repl.rli.on 'exit', -> fs.close fd


### PR DESCRIPTION
With a recent version of Node, every line of the REPL shows this warning:

    (node:6996) DeprecationWarning: Calling an asynchronous function without callback is deprecated.

This is happening because we call fs.write without a callback. Call
fs.writeSync instead. Upstream CoffeeScript has the same fix.